### PR TITLE
Adjustments to MainWindow.ui for window scaling

### DIFF
--- a/LynnaLab/Glade/MainWindow.ui
+++ b/LynnaLab/Glade/MainWindow.ui
@@ -22,8 +22,9 @@
     <property name="can-focus">False</property>
     <signal name="delete-event" handler="OnWindowClosed" swapped="no"/>
     <child>
-      <object class="GtkVBox" id="vbox1">
+      <object class="GtkBox" id="vbox1">
         <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">6</property>
         <child>
           <object class="GtkMenuBar" id="menubar1">
@@ -234,25 +235,20 @@
           </packing>
         </child>
         <child>
-          <placeholder/>
-        </child>
-        <child>
           <object class="GtkBox" id="overallEditingContainer">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="hexpand">True</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkVBox" id="vbox5">
+              <object class="GtkBox" id="vbox5">
                 <property name="can-focus">False</property>
-                <property name="hexpand">True</property>
+                <property name="halign">start</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">6</property>
                 <property name="spacing">6</property>
-                <child>
-                  <placeholder/>
-                </child>
-                <child>
-                  <placeholder/>
-                </child>
                 <child>
                   <object class="GtkNotebook" id="contextNotebook">
                     <property name="visible">True</property>
@@ -261,6 +257,8 @@
                       <object class="GtkBox">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="margin-start">3</property>
+                        <property name="margin-end">3</property>
                         <property name="margin-top">3</property>
                         <property name="margin-bottom">3</property>
                         <property name="orientation">vertical</property>
@@ -271,6 +269,10 @@
                             <property name="can-focus">False</property>
                             <property name="halign">center</property>
                             <property name="valign">center</property>
+                            <property name="margin-start">3</property>
+                            <property name="margin-end">3</property>
+                            <property name="margin-top">3</property>
+                            <property name="margin-bottom">3</property>
                             <property name="label-xalign">0.5</property>
                             <child>
                               <object class="GtkBox" id="tilesetViewerHolder">
@@ -304,6 +306,10 @@
                           <object class="GtkFrame" id="frame1">
                             <property name="can-focus">False</property>
                             <property name="halign">center</property>
+                            <property name="margin-start">3</property>
+                            <property name="margin-end">3</property>
+                            <property name="margin-top">3</property>
+                            <property name="margin-bottom">3</property>
                             <property name="label-xalign">0.5</property>
                             <child>
                               <object class="GtkAlignment" id="GtkAlignment">
@@ -350,14 +356,11 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkVBox" id="objectTab">
+                      <object class="GtkBox" id="objectTab">
                         <property name="can-focus">False</property>
                         <property name="margin-top">3</property>
                         <property name="margin-bottom">3</property>
                         <property name="spacing">6</property>
-                        <child>
-                          <placeholder/>
-                        </child>
                         <child>
                           <object class="GtkBox" id="objectGroupEditorHolder">
                             <property name="visible">True</property>
@@ -630,13 +633,17 @@
               <object class="GtkFrame">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="halign">center</property>
+                <property name="halign">start</property>
                 <property name="valign">start</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
                 <property name="label-xalign">0.5</property>
                 <child>
                   <object class="GtkBox" id="roomEditorHolder">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="valign">start</property>
                     <property name="orientation">vertical</property>
                     <child>
                       <placeholder/>
@@ -658,10 +665,14 @@
               </packing>
             </child>
             <child>
-              <object class="GtkVBox" id="vbox3">
+              <object class="GtkBox" id="vbox3">
                 <property name="can-focus">False</property>
-                <property name="halign">start</property>
-                <property name="valign">start</property>
+                <property name="halign">end</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">6</property>
+                <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkTable" id="table4">
@@ -735,9 +746,6 @@
                         <property name="position">1</property>
                       </packing>
                     </child>
-                    <child>
-                      <placeholder/>
-                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -749,10 +757,11 @@
                   <object class="GtkNotebook" id="minimapNotebook">
                     <property name="can-focus">True</property>
                     <child>
-                      <object class="GtkVBox" id="vbox4">
+                      <object class="GtkBox" id="vbox4">
                         <property name="can-focus">False</property>
                         <property name="halign">center</property>
                         <property name="valign">start</property>
+                        <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkBox">
@@ -853,13 +862,14 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkVBox" id="vbox7">
+                      <object class="GtkBox" id="vbox7">
                         <property name="can-focus">False</property>
                         <property name="halign">center</property>
                         <property name="valign">start</property>
+                        <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
-                          <!-- n-columns=3 n-rows=3 -->
+                          <!-- n-columns=2 n-rows=2 -->
                           <object class="GtkGrid">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
@@ -904,21 +914,6 @@
                                 <property name="left-attach">0</property>
                                 <property name="top-attach">1</property>
                               </packing>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
                             </child>
                           </object>
                           <packing>
@@ -973,6 +968,7 @@
                     <property name="can-focus">False</property>
                     <property name="receives-default">True</property>
                     <property name="halign">center</property>
+                    <property name="valign">start</property>
                     <signal name="clicked" handler="OnRedrawMinimapButtonClicked" swapped="no"/>
                   </object>
                   <packing>
@@ -990,7 +986,7 @@
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">3</property>
           </packing>
@@ -1006,8 +1002,9 @@
             </child>
           </object>
           <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack-type">end</property>
             <property name="position">4</property>
           </packing>
         </child>


### PR DESCRIPTION
The vboxes have been replaced with regular boxes because they're less frustrating in Glade. I have also added padding to the two side bars in the main editing area.